### PR TITLE
Omada add switch tests 2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1303,7 +1303,6 @@ omit =
     homeassistant/components/tplink_omada/controller.py
     homeassistant/components/tplink_omada/coordinator.py
     homeassistant/components/tplink_omada/entity.py
-    homeassistant/components/tplink_omada/switch.py
     homeassistant/components/tplink_omada/update.py
     homeassistant/components/traccar/device_tracker.py
     homeassistant/components/tractive/__init__.py

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -4,7 +4,9 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from tplink_omada_client.definitions import PoEMode
 from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
+from tplink_omada_client.omadasiteclient import SwitchPortOverrides
 
 from homeassistant.components.tplink_omada.config_flow import CONF_SITE
 from homeassistant.components.tplink_omada.const import DOMAIN
@@ -53,6 +55,16 @@ def mock_omada_site_client() -> Generator[AsyncMock, None, None]:
     )
     switch1_ports = [OmadaSwitchPortDetails(p) for p in switch1_ports_data]
     site_client.get_switch_ports.return_value = switch1_ports
+
+    async def mock_update_switch_port(
+        s, spd: OmadaSwitchPortDetails, overrides: SwitchPortOverrides
+    ) -> OmadaSwitchPortDetails:
+        spd.raw_data["poe"] = (
+            PoEMode.ENABLED if overrides.enable_poe else PoEMode.DISABLED
+        )
+        return spd
+
+    site_client.update_switch_port.side_effect = mock_update_switch_port
 
     return site_client
 

--- a/tests/components/tplink_omada/fixtures/switch-ports-TL-SG3210XHP-M2.json
+++ b/tests/components/tplink_omada/fixtures/switch-ports-TL-SG3210XHP-M2.json
@@ -726,7 +726,7 @@
     "switchId": "640934810000000000000000",
     "switchMac": "54-AF-97-00-00-01",
     "site": "000000000000000000000000",
-    "name": "Port8",
+    "name": "Renamed Port",
     "disable": false,
     "type": 1,
     "maxSpeed": 4,

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -1,15 +1,19 @@
 """Tests for TP-Link Omada switch entities."""
+from datetime import timedelta
+import json
 from unittest.mock import MagicMock
 
 from tplink_omada_client.devices import OmadaSwitchPortDetails
 from tplink_omada_client.omadasiteclient import SwitchPortOverrides
 
 from homeassistant.components import switch
+from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.dt import utcnow
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
 async def test_poe_switches(
@@ -19,7 +23,7 @@ async def test_poe_switches(
 ) -> None:
     """Test PoE switch."""
     poe_switch_mac = "54-AF-97-00-00-01"
-    for i in range(1, 9):
+    for i in range(1, 7):
         await _test_poe_switch(
             hass,
             mock_omada_site_client,
@@ -38,26 +42,40 @@ async def _test_poe_switch(
 ) -> None:
     entity_registry = er.async_get(hass)
 
-    poe_enable: bool = True
+    port_id = f"{port:024}"
 
-    async def assert_update_switch_port(
-        device, port, overrides: SwitchPortOverrides = None
+    def assert_update_switch_port(
+        device, called_port, poe_enable: bool, overrides: SwitchPortOverrides
     ):
         assert device
         assert device.mac == network_switch_mac
-        assert port
-        assert port.port == port
+        assert called_port
+        assert called_port.port_id == port_id
         assert overrides
         assert overrides.enable_poe == poe_enable
 
-        return OmadaSwitchPortDetails({"poe": 1 if overrides.enable_poe else 0})
+        # return OmadaSwitchPortDetails({"poe": 1 if overrides.enable_poe else 0})
 
     entity = hass.states.get(entity_name)
     assert entity
     assert entity.state == "on"
     entry = entity_registry.async_get(entity_name)
     assert entry
-    assert entry.unique_id == f"{network_switch_mac}_00000000000000000000000{port}_poe"
+    assert entry.unique_id == f"{network_switch_mac}_{port_id}_poe"
+
+    mock_omada_site_client.update_switch_port.reset_mock()
+    await call_service(hass, "turn_off", entity_name)
+    mock_omada_site_client.update_switch_port.assert_called_once()
+    device, switch_port = mock_omada_site_client.update_switch_port.call_args.args
+    assert_update_switch_port(
+        device,
+        switch_port,
+        False,
+        **mock_omada_site_client.update_switch_port.call_args.kwargs,
+    )
+    await hass.async_block_till_done()
+    entity = hass.states.get(entity_name)
+    assert entity.state == "off"
 
     mock_omada_site_client.update_switch_port.reset_mock()
     await call_service(hass, "turn_on", entity_name)
@@ -66,19 +84,69 @@ async def _test_poe_switch(
     assert_update_switch_port(
         device,
         switch_port,
+        True,
         **mock_omada_site_client.update_switch_port.call_args.kwargs,
     )
+    await hass.async_block_till_done()
+    entity = hass.states.get(entity_name)
+    assert entity.state == "on"
 
-    mock_omada_site_client.update_switch_port.reset_mock()
-    poe_enable = False
-    await call_service(hass, "turn_off", "switch.test_poe_switch_port_1_poe")
-    mock_omada_site_client.update_switch_port.assert_called_once()
-    device, switch_port = mock_omada_site_client.update_switch_port.call_args.args
-    assert_update_switch_port(
-        device,
-        switch_port,
-        **mock_omada_site_client.update_switch_port.call_args.kwargs,
+
+async def test_sfp_port_has_no_poe_switch(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test that a port that doesn't support SFTP isn't given a PoE switch entity."""
+    entity = hass.states.get("switch.test_poe_switch_port_10_poe")
+    assert entity is None
+
+
+async def test_poe_default_port_name(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test that a port with a default name is named correctly by the integration."""
+    entity = hass.states.get("switch.test_poe_switch_port_2_poe")
+    assert entity
+    assert entity.name == "Test PoE Switch Port 2 PoE"
+
+
+async def test_poe_custom_port_name(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test that a port with a custom name is named correctly by the integration."""
+    # Note: Port 8 has been renamed in the test fixture data
+    entity = hass.states.get("switch.test_poe_switch_port_8_renamed_port_poe")
+    assert entity
+    assert entity.name == "Test PoE Switch Port 8 (Renamed Port) PoE"
+
+
+async def test_poe_port_update_is_reflected_in_status(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test that when the API is polled for an update, the changes are reflected in the switch state."""
+    state = hass.states.get("switch.test_poe_switch_port_1_poe")
+    assert state.state == "on"
+
+    # Set up the API to return one of the ports as disabled
+    mock_omada_site_client.get_switch_ports.reset_mock()
+    switch1_ports_data = json.loads(
+        load_fixture("switch-ports-TL-SG3210XHP-M2.json", DOMAIN)
     )
+    switch1_ports_data[0]["poe"] = 0  # PoEMode.DISABLED
+    switch1_ports = [OmadaSwitchPortDetails(p) for p in switch1_ports_data]
+    mock_omada_site_client.get_switch_ports.return_value = switch1_ports
+
+    # Cause the coordinator to refresh the data from the API
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=600))
+    await hass.async_block_till_done()
+
+    mock_omada_site_client.get_switch_ports.assert_called_once()
+    state = hass.states.get("switch.test_poe_switch_port_1_poe")
+    assert state.state == "off"
 
 
 def call_service(hass, service, entity_id):

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -54,17 +54,15 @@ async def _test_poe_switch(
         assert overrides
         assert overrides.enable_poe == poe_enable
 
-        # return OmadaSwitchPortDetails({"poe": 1 if overrides.enable_poe else 0})
-
-    entity = hass.states.get(entity_name)
+    entity = hass.states.get(entity_id)
     assert entity
     assert entity.state == "on"
-    entry = entity_registry.async_get(entity_name)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == f"{network_switch_mac}_{port_id}_poe"
 
     mock_omada_site_client.update_switch_port.reset_mock()
-    await call_service(hass, "turn_off", entity_name)
+    await call_service(hass, "turn_off", entity_id)
     mock_omada_site_client.update_switch_port.assert_called_once()
     device, switch_port = mock_omada_site_client.update_switch_port.call_args.args
     assert_update_switch_port(
@@ -74,11 +72,11 @@ async def _test_poe_switch(
         **mock_omada_site_client.update_switch_port.call_args.kwargs,
     )
     await hass.async_block_till_done()
-    entity = hass.states.get(entity_name)
+    entity = hass.states.get(entity_id)
     assert entity.state == "off"
 
     mock_omada_site_client.update_switch_port.reset_mock()
-    await call_service(hass, "turn_on", entity_name)
+    await call_service(hass, "turn_on", entity_id)
     mock_omada_site_client.update_switch_port.assert_called_once()
     device, switch_port = mock_omada_site_client.update_switch_port.call_args.args
     assert_update_switch_port(
@@ -88,7 +86,7 @@ async def _test_poe_switch(
         **mock_omada_site_client.update_switch_port.call_args.kwargs,
     )
     await hass.async_block_till_done()
-    entity = hass.states.get(entity_name)
+    entity = hass.states.get(entity_id)
     assert entity.state == "on"
 
 


### PR DESCRIPTION
Hey Mike, as discussed here are some fixes to the proposed unit tests for omada poe switch entities.
This fixes a problem where the asserting function wasn't awaited, so never actually asserted the changes.
I've also increased the coverage to 100%